### PR TITLE
Check base for modifications to prevent false positives

### DIFF
--- a/.github/workflows/verify_signatures.yml
+++ b/.github/workflows/verify_signatures.yml
@@ -18,6 +18,7 @@ jobs:
         id: changed-parent
         uses: tj-actions/changed-files@v35.4.4
         with:
+          base_sha: ${{ github.event.pull_request.base.sha }}
           files_ignore: |
             signatures/*
 
@@ -25,6 +26,7 @@ jobs:
         id: changed-signatures
         uses: tj-actions/changed-files@v35.4.4
         with:
+          base_sha: ${{ github.event.pull_request.base.sha }}
           files: signatures/*
           match_directories: false
 


### PR DESCRIPTION
There was a problem with the previous file checker logic where if multiple commits were created, lets say to resolve a signature issue, the subsequent commits would be considered to modifying the signature file.

To get around this we will look at the base of the PR when determining what files have been changed and how.